### PR TITLE
mkimage.sh: use mformat -C for creating disk image

### DIFF
--- a/image/mkimage.sh
+++ b/image/mkimage.sh
@@ -23,7 +23,7 @@ else
 fi
 
 # check for tools
-if ! which mdir > /dev/null 2>&1; then
+if ! command -v mdir > /dev/null 2>&1; then
 	echo "error: Mtools needed"
 	exit 1
 fi

--- a/image/mkimage.sh
+++ b/image/mkimage.sh
@@ -4,6 +4,8 @@
 
 IMAGE=edrdos.img
 LABEL=EDR-DOS
+SIZE=1440
+SERIAL=0x306de779
 
 # determine operating mode
 if [ "$1" = "singlefile" -o "$1" = "" ]; then
@@ -21,28 +23,24 @@ else
 fi
 
 # check for tools
-if ! command -v mdir --help >/dev/null 2>&1; then
+if ! which mdir > /dev/null 2>&1; then
 	echo "error: Mtools needed"
 	exit 1
 fi
 
-# create a blank, formatted 1.44M image
-dd if=/dev/zero of=$IMAGE bs=512 count=2880
-mformat -i $IMAGE -v $LABEL
-
-# copy kernel to image
+# create a blank, formatted image and copy kernel to image
 case $MODE in
 singlefile)
-	dd if=bootfdos.144 of=$IMAGE bs=512 count=1 conv=notrunc
+	mformat -i $IMAGE -B bootfdos.144 -k -v $LABEL -f $SIZE -N $SERIAL -C
 	mcopy -i $IMAGE ../bin/kernel.sys ::/kernel.sys
 	;;
 dualfile)
-	dd if=bootedr.144 of=$IMAGE bs=512 count=1 conv=notrunc
+	mformat -i $IMAGE -B bootedr.144 -k -v $LABEL -f $SIZE -N $SERIAL -C
 	mcopy -i $IMAGE ../bin/drbio.sys ::/
 	mcopy -i $IMAGE ../bin/drdos.sys ::/
 	;;
 singlefile-drbio)
-	dd if=bootedr.144 of=$IMAGE bs=512 count=1 conv=notrunc
+	mformat -i $IMAGE -B bootedr.144 -k -v $LABEL -f $SIZE -N $SERIAL -C
 	mcopy -i $IMAGE ../bin/kernel.sys ::/drbio.sys
 	;;
 esac


### PR DESCRIPTION
I tried to build SvarDOS/edrdos disk image on OpenBSD, following error occured:

```
uaa@framboise:~/z/edrdos/image$ sh mkimage.sh
Making single-file KERNEL.SYS image.
2880+0 records in
2880+0 records out
1474560 bytes transferred in 0.008 secs (178053904 bytes/sec)
1+0 records in
1+0 records out
512 bytes transferred in 0.000 secs (37347727 bytes/sec)
Cluster # at 2048 too big(0xff0)
Probably non MS-DOS disk
Cannot initialize '::'
Bad target ::/kernel.sys
Cluster # at 2048 too big(0xff0)
Probably non MS-DOS disk
Cannot initialize '::'
Cluster # at 2048 too big(0xff0)
Probably non MS-DOS disk
Cannot initialize '::'
Bad target ::/
Cluster # at 2048 too big(0xff0)
Probably non MS-DOS disk
Cannot initialize '::'
Bad target ::/
```
I thought writng boot sector by dd after creating disk image with mformat makes things worse, so only using mformat to create blank disk image. But this method has side effect; last sector have something.

And, this sctipt cannot find mtools at non-standard (such as /usr/local/bin), this is fixed.
